### PR TITLE
Feat/platform engineering profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,9 +226,7 @@ Self-service           →  Developer Portal          →  Backstage
 <img height="160" src="https://github-readme-stats.vercel.app/api?username=hugosleao&show_icons=true&theme=dark&hide_border=true&count_private=true&bg_color=0d1117&title_color=00ADD8&icon_color=00ADD8" />
 <img height="160" src="https://github-readme-stats.vercel.app/api/top-langs/?username=hugosleao&layout=compact&theme=dark&hide_border=true&bg_color=0d1117&title_color=00ADD8&langs_count=6" />
 
-<br/>
 
-![GitHub Streak](https://streak-stats.demolab.com?user=hugosleao&theme=dark&hide_border=true&background=0d1117&ring=00ADD8&fire=00ADD8&currStreakLabel=00ADD8)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -223,10 +223,8 @@ Self-service           →  Developer Portal          →  Backstage
 
 <div align="center">
 
-<img height="160" src="https://github-readme-stats.vercel.app/api?username=hugosleao&show_icons=true&theme=dark&hide_border=true&count_private=true&bg_color=0d1117&title_color=00ADD8&icon_color=00ADD8" />
-<img height="160" src="https://github-readme-stats.vercel.app/api/top-langs/?username=hugosleao&layout=compact&theme=dark&hide_border=true&bg_color=0d1117&title_color=00ADD8&langs_count=6" />
-
-
+[![GitHub Stats](https://github-readme-stats.vercel.app/api?username=hugosleao&show_icons=true&theme=dark&hide_border=true&count_private=true&bg_color=0d1117&title_color=00ADD8&icon_color=00ADD8)](https://github.com/hugosleao)
+[![Top Languages](https://github-readme-stats.vercel.app/api/top-langs/?username=hugosleao&layout=compact&theme=dark&hide_border=true&bg_color=0d1117&title_color=00ADD8&langs_count=6)](https://github.com/hugosleao)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -219,17 +219,6 @@ Self-service           →  Developer Portal          →  Backstage
 
 ---
 
-## 📊 Stats
-
-<div align="center">
-
-[![GitHub Stats](https://github-readme-stats.vercel.app/api?username=hugosleao&show_icons=true&theme=dark&hide_border=true&count_private=true&bg_color=0d1117&title_color=00ADD8&icon_color=00ADD8)](https://github.com/hugosleao)
-[![Top Languages](https://github-readme-stats.vercel.app/api/top-langs/?username=hugosleao&layout=compact&theme=dark&hide_border=true&bg_color=0d1117&title_color=00ADD8&langs_count=6)](https://github.com/hugosleao)
-
-</div>
-
----
-
 <div align="center">
 
 *Building platforms where developers focus on code — the platform handles everything else.*


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to a profile README; no runtime, security, or data-handling impact.
> 
> **Overview**
> Removes the `## 📊 Stats` section from `README.md`, including embedded GitHub stats/top-langs images and the streak graphic, leaving the rest of the profile content unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c90d6d954dc29316b76a9df9955a3907cbe14e8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->